### PR TITLE
Integrate OAuth2 authorization flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_OAUTH_CLIENT_ID=your-client-id
+VITE_OAUTH_REDIRECT_URI=http://localhost:5173/oauth/callback
+VITE_API_BASE=http://localhost:8000/api

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SSO Frontend
 
-Aplicación de ejemplo para autenticación simple basada en JWT y cookies utilizando React con Vite.
+Aplicación de ejemplo para autenticación simple basada en JWT y cookies utilizando React con Vite. Incluye soporte para identidad federada a través de OAuth2 con `django-oauth-toolkit`.
 
 ## Características
 
@@ -9,10 +9,15 @@ Aplicación de ejemplo para autenticación simple basada en JWT y cookies utiliz
 - Control de sesión global con React Context.
 - Rutas protegidas usando `react-router-dom`.
 - Estilos con Tailwind CSS y componentes de Heroicons.
+- Integración con OAuth2 para identidad federada.
 
 ## Requisitos
 
 - Node.js 18 o superior
+- Configurar las variables de entorno del cliente OAuth en un archivo `.env`:
+  - `VITE_OAUTH_CLIENT_ID` – identificador del cliente público registrado en el backend.
+  - `VITE_OAUTH_REDIRECT_URI` – URL de retorno autorizada para el flujo OAuth2.
+  - `VITE_API_BASE` – URL base de la API del backend.
 - Un backend compatible que exponga los siguientes endpoints:
   - `POST /token/` para obtener tokens con usuario y contraseña.
   - `POST /token/cookie/` para obtener `access` y almacenar `refresh_token` en una cookie.
@@ -29,7 +34,13 @@ Aplicación de ejemplo para autenticación simple basada en JWT y cookies utiliz
    npm install
    ```
 
-2. Inicia el servidor de desarrollo:
+2. Copia el archivo `.env.example` como `.env` y ajusta los valores de las variables:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Inicia el servidor de desarrollo:
 
    ```bash
    npm run dev

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -27,6 +27,23 @@ export const getUserInfo = async () => {
   return response.data;
 };
 
+export const exchangeAuthorizationCode = async (
+  code,
+  redirectUri,
+  clientId
+) => {
+  const params = new URLSearchParams();
+  params.append("grant_type", "authorization_code");
+  params.append("code", code);
+  params.append("redirect_uri", redirectUri);
+  if (clientId) params.append("client_id", clientId);
+
+  const response = await API.post("/o/token/", params, {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  return response.data;
+};
+
 export const logout = async () => {
   await API.post("/logout/");
 };

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -5,8 +5,10 @@ import { getGlobalLogout } from "../context/AuthContext";
 
 const EXCLUDED_ENDPOINTS = ["/token", "/token/cookie", "/token/refresh", "/register"];
 
+export const API_BASE_URL = import.meta.env.VITE_API_BASE || "http://localhost:8000/api";
+
 const API = axios.create({
-    baseURL: "http://localhost:8000/api",
+    baseURL: API_BASE_URL,
     withCredentials: true, // usa cookie refresh_token
 });
 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,10 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { getUserInfo, loginWithCookie, logout as apiLogout } from "../api/auth";
+import {
+  getUserInfo,
+  loginWithCookie,
+  logout as apiLogout,
+  exchangeAuthorizationCode,
+} from "../api/auth";
 import { useNavigate } from "react-router-dom";
 
 const AuthContext = createContext();
@@ -46,13 +51,26 @@ export const AuthProvider = ({ children }) => {
     await loadUser();
   };
 
+  const loginWithCode = async (code) => {
+    setIsAuthenticating(true);
+    const { access } = await exchangeAuthorizationCode(
+      code,
+      import.meta.env.VITE_OAUTH_REDIRECT_URI,
+      import.meta.env.VITE_OAUTH_CLIENT_ID
+    );
+    localStorage.setItem("access", access);
+    await loadUser();
+  };
+
   useEffect(() => {
     const access = localStorage.getItem("access");
     if (access) loadUser();
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, isAuthenticating }}>
+    <AuthContext.Provider
+      value={{ user, login, loginWithCode, logout, isAuthenticating }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
+import { API_BASE_URL } from "../api/axios";
 
 import {
   LockClosedIcon,
@@ -15,6 +16,14 @@ export default function Login() {
 
   const navigate = useNavigate();
   const { login } = useAuth();
+  const oauthLogin = () => {
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: import.meta.env.VITE_OAUTH_CLIENT_ID,
+      redirect_uri: import.meta.env.VITE_OAUTH_REDIRECT_URI,
+    });
+    window.location.href = `${API_BASE_URL}/o/authorize/?${params.toString()}`;
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -81,6 +90,13 @@ export default function Login() {
             className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 rounded-lg transition"
           >
             Entrar
+          </button>
+          <button
+            type="button"
+            onClick={oauthLogin}
+            className="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2 rounded-lg transition"
+          >
+            Entrar con identidad federada
           </button>
           <p className="text-sm text-center mt-4 text-gray-600 dark:text-gray-400">
             ¿No tienes cuenta?{" "}

--- a/src/pages/OAuthAuthorize.jsx
+++ b/src/pages/OAuthAuthorize.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import API from "../api/axios";
+
+export default function OAuthAuthorize() {
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const clientId = params.get("client_id");
+  const [client, setClient] = useState(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (clientId) {
+      API.get(`/oauth/clients/${clientId}/`)
+        .then((res) => setClient(res.data))
+        .catch(() => setError("No se pudo obtener la información de la aplicación"));
+    } else {
+      setError("Solicitud inválida");
+    }
+  }, [clientId]);
+
+  if (error) {
+    return <p className="p-6 text-center text-red-500">{error}</p>;
+  }
+
+  if (!client) {
+    return <p className="p-6 text-center">Cargando...</p>;
+  }
+
+  const redirectToBackend = (allow) => {
+    const q = new URLSearchParams(search);
+    q.set("allow", allow ? "true" : "false");
+    window.location.href = `${API.defaults.baseURL}/o/authorize/?${q.toString()}`;
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md w-full max-w-md text-center">
+        <h1 className="text-lg font-semibold mb-4">
+          {client.name || clientId} solicita acceso
+        </h1>
+        <p className="text-sm mb-6">¿Deseas conceder acceso a esta aplicación?</p>
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={() => redirectToBackend(true)}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            Autorizar
+          </button>
+          <button
+            onClick={() => redirectToBackend(false)}
+            className="px-4 py-2 bg-gray-300 dark:bg-gray-700 rounded hover:bg-gray-400 dark:hover:bg-gray-600"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/OAuthCallback.jsx
+++ b/src/pages/OAuthCallback.jsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function OAuthCallback() {
+  const navigate = useNavigate();
+  const { loginWithCode } = useAuth();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    if (code) {
+      loginWithCode(code).then(() => navigate("/dashboard"));
+    } else {
+      navigate("/login");
+    }
+  }, [loginWithCode, navigate]);
+
+  return <p className="p-6 text-center">Procesando autenticación...</p>;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -4,12 +4,16 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import Dashboard from "./pages/Dashboard";
 import ProtectedLayout from "./components/ProtectedLayout";
 import Register from "./pages/Register";
+import OAuthAuthorize from "./pages/OAuthAuthorize";
+import OAuthCallback from "./pages/OAuthCallback";
 
 export default function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
+      <Route path="/oauth/authorize" element={<OAuthAuthorize />} />
+      <Route path="/oauth/callback" element={<OAuthCallback />} />
       <Route
         path="/"
         element={


### PR DESCRIPTION
## Summary
- add OAuth2 configuration example
- ignore `.env` files
- export `API_BASE_URL`
- implement OAuth authorization code exchange
- support login with authorization code in auth context
- add OAuth login button and new routes
- create authorization and callback pages
- document OAuth2 variables and features

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68558e381f3c83289870d09b6d4b561a