### PR TITLE
Fix login redirect when no token

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -64,7 +64,11 @@ export const AuthProvider = ({ children }) => {
 
   useEffect(() => {
     const access = localStorage.getItem("access");
-    if (access) loadUser();
+    if (access) {
+      loadUser();
+    } else {
+      setIsAuthenticating(false);
+    }
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- ensure isAuthenticating is disabled when no access token is found

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685590bfe22883289bbcabadb4cfcdbf