### PR TITLE
Update frontend for email-based authentication

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,17 +1,17 @@
 // src/api/auth.js
 import API from "./axios";
 
-export const login = async (username, password) => {
+export const login = async (email, password) => {
   const response = await API.post("/token/", {
-    username,
+    email,
     password,
   });
   return response.data;
 };
 
-export const loginWithCookie = async (username, password) => {
+export const loginWithCookie = async (email, password) => {
   const response = await API.post("/token/cookie/", {
-    username,
+    email,
     password,
   });
   return response.data;

--- a/src/components/ProtectedLayout.jsx
+++ b/src/components/ProtectedLayout.jsx
@@ -18,7 +18,7 @@ export default function ProtectedLayout() {
         <h1 className="text-xl font-semibold">Panel de usuario</h1>
         <div className="flex items-center gap-4">
           <span className="text-sm text-gray-600 dark:text-gray-300">
-            {user?.username}
+            {user?.email}
           </span>
           <button
             onClick={handleLogout}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -43,9 +43,9 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  const login = async (username, password) => {
+  const login = async (email, password) => {
     setIsAuthenticating(true);
-    const { access } = await loginWithCookie(username, password);
+    const { access } = await loginWithCookie(email, password);
     localStorage.setItem("access", access);
     await loadUser();
   };

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -9,7 +9,7 @@ import {
 } from "@heroicons/react/24/outline";
 
 export default function Login() {
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
 
@@ -19,7 +19,7 @@ export default function Login() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await login(username, password);
+      await login(email, password);
       navigate("/dashboard");
     } catch {
       setError("Credenciales inválidas o sesión fallida.");
@@ -48,13 +48,13 @@ export default function Login() {
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
-              Usuario
+              Email
             </label>
             <div className="relative">
               <input
-                type="text"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
                 required
                 className="w-full pl-10 pr-4 py-2 rounded-lg border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
               />

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -2,14 +2,12 @@ import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import {
   LockClosedIcon,
-  UserIcon,
   EnvelopeIcon,
 } from "@heroicons/react/24/outline";
 import axios from "axios";
 
 export default function Register() {
   const [formData, setFormData] = useState({
-    username: "",
     email: "",
     password: "",
     confirm_password: "",
@@ -35,7 +33,6 @@ export default function Register() {
 
     try {
       await axios.post("http://localhost:8000/api/register/", {
-        username: formData.username,
         email: formData.email,
         password: formData.password,
         confirm_password: formData.confirm_password,
@@ -69,13 +66,6 @@ export default function Register() {
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          <InputField
-            label="Usuario"
-            name="username"
-            icon={UserIcon}
-            value={formData.username}
-            onChange={handleChange}
-          />
           <InputField
             label="Email"
             name="email"


### PR DESCRIPTION
## Summary
- remove username field from registration form
- replace username with email for login
- update API calls and AuthContext to send `email`
- display `email` for logged user

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b4a4842bc8328a223e403f8fa2f28